### PR TITLE
support_pkpass_files_e_wallet

### DIFF
--- a/android/src/main/java/com/alinz/parkerdan/shareextension/RealPathUtil.java
+++ b/android/src/main/java/com/alinz/parkerdan/shareextension/RealPathUtil.java
@@ -149,19 +149,26 @@ public class RealPathUtil {
             }
         }
 
-        String dataFromUri = getDataColumn(context, uri, null, null);
 
-        if (dataFromUri == null) {
+        if (fileExtension.equals("application/vnd.apple.pkpass")) {
             return copyFile(context, uri, fileExtension);
+        } else {
+
+            String dataFromUri = getDataColumn(context, uri, null, null);
+
+            if (dataFromUri == null) {
+                return copyFile(context, uri, fileExtension);
+            }
+
+            String[] arrOfStrings = dataFromUri.split("content://");
+
+            if (arrOfStrings.length > 1) {
+                return copyFile(context, uri, fileExtension);
+            }
+
+            return dataFromUri;
         }
 
-        String[] arrOfStrings = dataFromUri.split("content://");
-
-        if (arrOfStrings.length > 1) {
-            return copyFile(context, uri, fileExtension);
-        }
-
-        return dataFromUri;
     }
 
     /**
@@ -193,6 +200,9 @@ public class RealPathUtil {
                 break;
             case "application/pdf":
                 extension = ".pdf";
+                break;
+            case "application/vnd.apple.pkpass":
+                extension = ".zip";
                 break;
             default:
                 extension = ".jpg";

--- a/android/src/main/java/com/alinz/parkerdan/shareextension/ShareModule.java
+++ b/android/src/main/java/com/alinz/parkerdan/shareextension/ShareModule.java
@@ -65,6 +65,10 @@ public class ShareModule extends ReactContextBaseJavaModule {
                 Uri uri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
                 value = "file://" + RealPathUtil.getRealPathFromURI(currentActivity, uri, type);
                 intent.setType("clear");
+            } else if (Intent.ACTION_SEND.equals(action) && ("application/vnd.apple.pkpass".equals(type))) {
+                Uri uri = (Uri) intent.getParcelableExtra(Intent.EXTRA_STREAM);
+                value = "file://" + RealPathUtil.getRealPathFromURI(currentActivity, uri, type);
+                intent.setType("clear");
             } else if ("clear".equals(type)) {
                 value = "";
                 type = "";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@refundit/react-native-share-extension",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "description": "share extension using react-native for both ios and android",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
Handle .pkpass files (apple wallet original) for ios and android. In Android the file will be renamed as .zip to further extraction. On iOS the share support only from email/files as a file and not from the wallet app.